### PR TITLE
Fix ns to string bug in cljs.test/run-all-tests

### DIFF
--- a/src/sci/configs/cljs/test.cljs
+++ b/src/sci/configs/cljs/test.cljs
@@ -1074,7 +1074,7 @@
                   (fn [ns]
                     `(quote ~ns))
                   (cond->> (sci/eval-form (store/get-ctx) '(all-ns))
-                    re (filter #(re-matches re (name %))))))))
+                    re (filter #(re-matches re (name (ns-name %)))))))))
 
 (defn ^:macro use-fixtures [_ _ type & fns]
   (condp = type


### PR DESCRIPTION
I've got a namespace in my classpath called "gracie.projects2" with a filepath like `src/gracie/projects2.cljs`. I have code based on your testing example:

```cljs
(t/run-all-tests #"^gracie\.tests\.") 
```

Running it throws the following error:

> Doesn't support name: gracie.projects2

Digging around the clojuredocs.org docs for all-ns, found a user exploring all-ns like the following:

```cljs
(->> (all-ns)
     (map ns-name)
     (map name))
```

That seems to work more reliably for getting the string name of all the namespaces.

Quick test to confirm:

```cljs
(->> (all-ns)
     (map name))
```

Throws that error described above.

```cljs
(->> (all-ns)
     (map ns-name)
     (map name))
```

Works as expected returning a list of string namespace names.