### PR TITLE
Rm unnecessary security, fix test gist link

### DIFF
--- a/playground/www/index.html
+++ b/playground/www/index.html
@@ -39,17 +39,12 @@
 
   <h4 id="gist-info">Auto-evaluation GitHub gists</h4>
   <p>You can automatically load and evaluate a <a href="https://gist.github.com/discover">gist</a>
-    by appending <code>?gist=GIST-ID</code> to the URL. All clj* files from the gist are loaded 
+    by appending <code>?gist=GIST-ID</code> to the URL. All clj* files from the gist are loaded
     into the editor in the order of their names and evaluated automatically. You can
-    <a href="/?gist=5ff187847756263be17d7c4c19f978b5">try our test gist (by clicking here)</a>.
-  </p>
-  <p>
-    Notice that for security reasons, auto-evaluated gists lack access to <code>js/*</code>
-    and some JS libs, unless you include <code>&amp;unlimited</code> in the URL.
-    This is not true when you evaluate them manually.
+    <a href="?gist=5ff187847756263be17d7c4c19f978b5">try our test gist (by clicking here)</a>.
   </p>
   <p>BEWARE: Evaluating code from a random source is dangerous, even though SCI does its best to sandbox
-    scripts.
+    scripts. The scripts have access to <code>js/{document, window, ...}</code>.
   </p>
 </body>
 <script src="js/playground.js"></script>


### PR DESCRIPTION
Don't limit auto-evaluated gists in access to js/*, people will click on links anyway, not checking for `&unlimited`.

Fix the test gist link to work also when not running at root.