### PR TITLE
Upgrade Hoplon and Javelin deps, improve macro support for both

### DIFF
--- a/playground/src/playground.cljs
+++ b/playground/src/playground.cljs
@@ -36,7 +36,7 @@
    sci.configs.tonsky.datascript
    sci.configs.hoplon.javelin
    sci.configs.hoplon.hoplon
-   hoplon.goog
+   hoplon.dom
 
    [sci.core :as sci]
    [sci.ctx-store :as store]))

--- a/src/sci/configs/hoplon/hoplon.cljs
+++ b/src/sci/configs/hoplon/hoplon.cljs
@@ -1,6 +1,7 @@
 (ns sci.configs.hoplon.hoplon
   (:refer-clojure :exclude [dosync defmacro])
   (:require [sci.core :as sci]
+            [sci.ctx-store :as ctx-store]
             [clojure.set]
             [javelin.core :as j]
             [hoplon.core]
@@ -48,6 +49,162 @@
   (let [parts (remove #(= "" %) (terpol8* s))]
     (if (every? string? parts) s `(str ~@parts))))
 
+(m/defmacro elem
+  "Create an anonymous custom element."
+  [bind & body]
+  (let [[prepost & body] (if (map? (first body)) body (conj body nil))]
+    `(fn [& args#] ~(or prepost {}) (let [~bind (hoplon.core/parse-args args#)] ~@body))))
+
+(def sci-macroexpand-1 (delay (sci/eval-string* (ctx-store/get-ctx) "macroexpand-1")))
+(defn macroexpand-1*
+  ([expr] (macroexpand-1* {} expr))
+  ([_env expr] (@sci-macroexpand-1 expr)))
+
+(m/defmacro defelem
+  "Defines an element function.
+
+  An element function creates a DOM Element (parent) given two arguments:
+
+    * `attrs` - a number of key-value pairs for attributes and their values
+    * `kids` - a sequence of DOM Elements to be appended/used inside
+
+  The returned DOM Element is itself a function which can accept more
+  attributes and child elements."
+  [name & forms]
+  (let [[_ name [_ & [fdecl]]] (macroexpand-1* `(defn ~name ~@forms))
+        [docstr & [bind & body]] (if (string? (first fdecl)) fdecl (conj fdecl nil))]
+    `(def ^{:doc ~docstr} ~name (hoplon.core/elem ~bind ~@body))))
+
+(m/defmacro defattr
+  "Defines an attribute function.
+
+  An element attribute is a function given three arguments:
+
+    * `elem` - the target DOM Element containing the attribute
+    * `key` - the attribute keyword or symbol
+    * `value` - the attribute value
+
+  The attribute function is called whenever the value argument changes."
+  [name & forms]
+  `(defmethod hoplon.core/do! ~name ~@forms))
+
+(m/defmacro ^:private safe-deref [expr] `(deref (or ~expr (atom nil))))
+
+(defn- parse-e [[tag & [head & tail :as args]]]
+   (let [kw1? (comp keyword? first)
+         mkkw #(->> (partition 2 %) (take-while kw1?) (map vec))
+         drkw #(->> (partition 2 2 [] %) (drop-while kw1?) (mapcat identity))]
+     (cond (map?     head) [tag head tail]
+          (keyword? head) [tag (into {} (mkkw args)) (drkw args)]
+           :else           [tag nil args])))
+
+(m/defmacro loop-tpl
+  "Template. Works identically to `for-tpl`, only expects a `:bindings`
+  attribute to accomodate the HTML HLisp representation:
+
+    (loop-tpl :bindings [x xs] ...)
+  "
+  [& args]
+  (let [[_ {[bindings items] :bindings} [body]] (parse-e (cons '_ args))]
+    `(hoplon.core/loop-tpl* ~items
+        (fn [item#] (j/cell-let [~bindings item#] ~body)))))
+
+(m/defmacro for-tpl
+  "Template. Accepts a cell-binding and returns a cell containing a sequence of
+  elements:
+
+    (for-tpl [x xs] (span x))
+  "
+  [[bindings items] body]
+  `(hoplon.core/loop-tpl* ~items (fn [item#] (j/cell-let [~bindings item#] ~body))))
+
+(m/defmacro if-tpl
+  "Template. Accepts a `predicate` cell and returns a cell containing either
+  the element produced by `consequent` or `alternative`, depending on the value
+  of the predicate:
+
+    (if-tpl predicate (span \"True\") (span \"False\"))
+  "
+  [predicate consequent & [alternative]]
+  `(let [con# (delay ~consequent)
+         alt# (delay ~alternative)
+         tpl# (fn [p#] (hoplon.core/safe-deref (if p# con# alt#)))]
+     ((j/formula tpl#) ~predicate)))
+
+(m/defmacro when-tpl
+  "Template. Accepts a `predicate` cell and returns a cell containing either
+  the element produced by `consequent` or nothing, depending on the value of
+  the predicate:
+
+    (when-tpl predicate (span \"Value\"))
+  "
+  [predicate & body]
+  `(hoplon.core/if-tpl ~predicate (do ~@body)))
+
+(m/defmacro cond-tpl
+  "Template. Accepts a number of `clauses` cell-template pairs and returns a
+  cell with the value produced by the matching clause:
+
+    (cond-tpl
+      clause-a (span \"A\")
+      clause-b (span \"B\")
+      :else    (span \"Default\"))
+  "
+  [& clauses]
+  (assert (even? (count clauses)))
+  (let [[conds tpls] (apply map vector (partition 2 clauses))
+        syms1        (repeatedly (count conds) gensym)
+        syms2        (repeatedly (count conds) gensym)]
+    `(let [~@(interleave syms1 (map (fn [x] `(delay ~x)) tpls))
+           tpl# (fn [~@syms2] (hoplon.core/safe-deref (cond ~@(interleave syms2 syms1))))]
+       ((j/formula tpl#) ~@conds))))
+
+(m/defmacro case-tpl
+  "Template. Accepts an `expr` cell and a number of `clauses` and returns a
+  cell with the value produced by the matching clause:
+
+    (case-tpl expr
+      :a (span \"A\")
+      :b (span \"B\")
+      (span \"Default\"))
+
+  "
+  [expr & clauses]
+  (let [[cases tpls] (apply map vector (partition 2 clauses))
+        default      (when (odd? (count clauses)) (last clauses))
+        syms         (repeatedly (inc (count cases)) gensym)]
+    `(let [~@(interleave syms (map (fn [x] `(delay ~x)) (conj tpls default)))
+           tpl# (fn [expr#] (hoplon.core/safe-deref (case expr# ~@(interleave cases syms) ~(last syms))))]
+       ((j/formula tpl#) ~expr))))
+
+;; DOM Macros ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(m/defmacro with-dom
+  "Evaluates the body after elem has been inserted into the DOM."
+  [elem & body]
+  `(hoplon.core/when-dom ~elem (fn [] ~@body)))
+
+(m/defmacro with-timeout
+  "Evaluates the body after msec milliseconds, asynchronously. Returns the
+  timeout ID which can be used to cancel the operation (see js/clearTimeout)."
+  [msec & body]
+  `(js/setTimeout (fn [] ~@body) ~msec))
+
+(m/defmacro with-interval
+  "Evaluates the body every msec milliseconds, asynchronously. Returns the
+  interval ID which can be used to cancel the operation (see js/clearInterval)."
+  [msec & body]
+  `(js/setInterval (fn [] ~@body) ~msec))
+
+(m/defmacro with-animation-frame
+  "Evaluates the body before the next browser repaint as requestAnimationFrame."
+  [& body]
+  `(.requestAnimationFrame js/window (fn [] ~@body)))
+
+(m/defmacro with-init!
+  "Evaluates the body after Hoplon has completed constructing the page."
+  [& body]
+  `(hoplon.core/add-initfn! (fn [] ~@body)))
+
 (m/defmacro text
   "Creates a DOM Text node and binds its text content to a formula created via
   string interpolation, so the Text node updates with the formula."
@@ -61,6 +218,21 @@
 (def hns (sci/create-ns 'hoplon.core nil))
 
 (def hoplon-core-namespace (assoc (sci/copy-ns hoplon.core hns)
-                                  'text (sci/copy-var text hns)))
+                                  'text (sci/copy-var text hns)
+                                  'elem (sci/copy-var elem hns)
+                                  'defelem (sci/copy-var defelem hns)
+                                  'defattr (sci/copy-var defattr hns)
+                                  'safe-deref (sci/copy-var safe-deref hns)
+                                  'loop-tpl (sci/copy-var loop-tpl hns)
+                                  'for-tpl (sci/copy-var for-tpl hns)
+                                  'if-tpl (sci/copy-var if-tpl hns)
+                                  'when-tpl (sci/copy-var when-tpl hns)
+                                  'cond-tpl (sci/copy-var cond-tpl hns)
+                                  'case-tpl (sci/copy-var case-tpl hns)
+                                  'with-dom (sci/copy-var with-dom hns)
+                                  'with-timeout (sci/copy-var with-timeout hns)
+                                  'with-interval (sci/copy-var with-interval hns)
+                                  'with-animation-frame (sci/copy-var with-animation-frame hns)
+                                  'with-init! (sci/copy-var with-init! hns)))
 
 (def config {:namespaces {'hoplon.core hoplon-core-namespace}})

--- a/test-deps/deps.edn
+++ b/test-deps/deps.edn
@@ -8,7 +8,7 @@
                    :git/sha "e503874b154224ce85b223144e80b697df91d18e"}
   reagent/reagent {:mvn/version "1.1.0"}
   re-frame/re-frame {:mvn/version "1.3.0"}
-  hoplon/javelin {:mvn/version "3.9.0"}
-  hoplon/hoplon {:mvn/version "7.3.4"}
+  hoplon/javelin {:mvn/version "3.9.3"}
+  hoplon/hoplon {:mvn/version "7.5.0"}
   datascript/datascript {:mvn/version "1.5.3"}
   cljs-bean/cljs-bean {:mvn/version "1.9.0"}}}


### PR DESCRIPTION
* upgrade Hoplon and Javelin to the latest versions
* all macros are working except:
    * `h/formula-of`
    * `h/formulet`
    * `h/cond-tpl`

I'm not sure what is wrong with those as there is no output neither on console nor errors reported on the playground ui.
I think this is a big improvement even without those macros, and we could try to add them later.