### PR TITLE
Re frame alpha config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Public API:
 
 - `config`
 - `re-frame-namespace`
+- `re-frame-db-namespace`
 - `namespaces`
 
 ### [mfikes/cljs-bean](https://github.com/mfikes/cljs-bean)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Public API:
 - `config`
 - `re-frame-namespace`
 - `re-frame-db-namespace`
-- `re-frame-alpha-namespace`
 - `namespaces`
 
 ### [mfikes/cljs-bean](https://github.com/mfikes/cljs-bean)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Public API:
 - `config`
 - `re-frame-namespace`
 - `re-frame-db-namespace`
+- `re-frame-alpha-namespace`
 - `namespaces`
 
 ### [mfikes/cljs-bean](https://github.com/mfikes/cljs-bean)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ Public API:
 - `re-frame-db-namespace`
 - `namespaces`
 
+The configuration for `re-frame.alpha` is available seperately via:
+
+Namespace: `sci.configs.re-frame.re-frame-alpha`
+
+Public API:
+
+- `config`
+- `re-frame-alpha-namespace`
+
+
 ### [mfikes/cljs-bean](https://github.com/mfikes/cljs-bean)
 
 Namespace: `sci.configs.mfikes.cljs-bean`

--- a/playground/www/index.html
+++ b/playground/www/index.html
@@ -18,7 +18,7 @@
         [promesa.core :as p]
         [cljs-bean.core :refer [bean ->clj ->js]]
         [re-frame.core :as rf]
-        [re-frame.db :as r.db]
+        [re-frame.db :as rf.db]
         [reagent.core :as r]
         [reagent.dom.server :as rds]
         [reagent.debug]

--- a/playground/www/index.html
+++ b/playground/www/index.html
@@ -19,6 +19,7 @@
         [cljs-bean.core :refer [bean ->clj ->js]]
         [re-frame.core :as rf]
         [re-frame.db :as rf.db]
+        [re-frame.alpha :as rf.a]
         [reagent.core :as r]
         [reagent.dom.server :as rds]
         [reagent.debug]

--- a/playground/www/index.html
+++ b/playground/www/index.html
@@ -19,7 +19,6 @@
         [cljs-bean.core :refer [bean ->clj ->js]]
         [re-frame.core :as rf]
         [re-frame.db :as rf.db]
-        [re-frame.alpha :as rf.a]
         [reagent.core :as r]
         [reagent.dom.server :as rds]
         [reagent.debug]

--- a/src/sci/configs/re_frame/re_frame.cljs
+++ b/src/sci/configs/re_frame/re_frame.cljs
@@ -2,10 +2,12 @@
   (:require
    [re-frame.core]
    [re-frame.db]
+   [re-frame.alpha]
    [sci.core :as sci]))
 
 (def rfns (sci/create-ns 're-frame.core nil))
 (def rfdbns (sci/create-ns 're-frame.db nil))
+(def rfa (sci/create-ns 're-frame.alpha nil))
 
 (def re-frame-namespace
   (sci/copy-ns re-frame.core rfns))
@@ -13,9 +15,13 @@
 (def re-frame-db-namespace
   (sci/copy-ns re-frame.db rfdbns))
 
+(def re-frame-alpha-namespace
+  (sci/copy-ns re-frame.alpha rfns))
+
 (def namespaces
   {'re-frame.core re-frame-namespace
-   're-frame.db re-frame-db-namespace})
+   're-frame.db re-frame-db-namespace
+   're-frame.alpha re-frame-alpha-namespace})
 
 (def config
   {:namespaces namespaces})

--- a/src/sci/configs/re_frame/re_frame.cljs
+++ b/src/sci/configs/re_frame/re_frame.cljs
@@ -2,12 +2,10 @@
   (:require
    [re-frame.core]
    [re-frame.db]
-   [re-frame.alpha]
    [sci.core :as sci]))
 
 (def rfns (sci/create-ns 're-frame.core nil))
 (def rfdbns (sci/create-ns 're-frame.db nil))
-(def rfa (sci/create-ns 're-frame.alpha nil))
 
 (def re-frame-namespace
   (sci/copy-ns re-frame.core rfns))
@@ -15,13 +13,9 @@
 (def re-frame-db-namespace
   (sci/copy-ns re-frame.db rfdbns))
 
-(def re-frame-alpha-namespace
-  (sci/copy-ns re-frame.alpha rfns))
-
 (def namespaces
   {'re-frame.core re-frame-namespace
-   're-frame.db re-frame-db-namespace
-   're-frame.alpha re-frame-alpha-namespace})
+   're-frame.db re-frame-db-namespace})
 
 (def config
   {:namespaces namespaces})

--- a/src/sci/configs/re_frame/re_frame_alpha.cljs
+++ b/src/sci/configs/re_frame/re_frame_alpha.cljs
@@ -1,0 +1,15 @@
+(ns sci.configs.re-frame.re-frame-alpha
+  (:require
+   [re-frame.alpha]
+   [sci.core :as sci]))
+
+(def rfa (sci/create-ns 're-frame.alpha nil))
+
+(def re-frame-alpha-namespace
+  (sci/copy-ns re-frame.alpha rfa))
+
+(def namespaces
+  {'re-frame.alpha re-frame-alpha-namespace})
+
+(def config
+  {:namespaces namespaces})

--- a/test-deps/deps.edn
+++ b/test-deps/deps.edn
@@ -7,7 +7,7 @@
   funcool/promesa {:git/url "https://github.com/funcool/promesa"
                    :git/sha "e503874b154224ce85b223144e80b697df91d18e"}
   reagent/reagent {:mvn/version "1.1.0"}
-  re-frame/re-frame {:mvn/version "1.3.0"}
+  re-frame/re-frame {:mvn/version "1.4.0"}
   hoplon/javelin {:mvn/version "3.9.3"}
   hoplon/hoplon {:mvn/version "7.5.0"}
   datascript/datascript {:mvn/version "1.5.3"}


### PR DESCRIPTION
Re-frame has a new `re-frame.alpha` ns since 1.4.0. Upgraded re-frame and integrated the alpha ns.