### PR TITLE
promesa.core/do is exception safe

### DIFF
--- a/src/sci/configs/funcool/promesa.cljs
+++ b/src/sci/configs/funcool/promesa.cljs
@@ -12,10 +12,10 @@
 (def pns (sci/create-ns 'promesa.core nil))
 (def ptns (sci/create-ns 'promesa.protocols nil))
 
-(defn ^:macro do!
-  "Execute potentially side effectful code and return a promise resolved
-  to the last expression. Always awaiting the result of each
-  expression."
+
+(defn ^:macro do*
+  "An exception unsafe do-like macro. Supposes that we are already
+  wrapped in promise context so avoids defensive wrapping."
   [_ _ & exprs]
   (condp = (count exprs)
     0 `(p/resolved nil)
@@ -24,6 +24,16 @@
               `(p/bind (p/promise ~e) (fn [_#] ~acc)))
             `(p/promise ~(last exprs))
             (reverse (butlast exprs)))))
+
+(defn ^:macro do
+  "Execute potentially side effectful code and return a promise resolved
+  to the last expression after awaiting the result of each
+  expression."
+  [_ _ & exprs]
+  `(p/bind
+    (p/promise nil)
+    (fn [_#]
+      (promesa.core/do* ~@exprs))))
 
 (defn ^:macro let*
   "An exception unsafe let-like macro. Supposes that we are already
@@ -175,9 +185,9 @@
    'create (sci/copy-var p/create pns)
    'deferred (sci/copy-var p/deferred pns)
    'delay (sci/copy-var p/delay pns)
-   'do (sci/copy-var do! pns)
-   'do* (sci/copy-var do! pns)
-   'do! (sci/copy-var do! pns)
+   'do (sci/copy-var do pns)
+   'do* (sci/copy-var do* pns)
+   'do! (sci/copy-var do pns)
    'done? (sci/copy-var p/done? pns)
    'error (sci/copy-var p/error pns)
    'extract (sci/copy-var p/extract pns)

--- a/test/funcool/promesa_test.cljc
+++ b/test/funcool/promesa_test.cljc
@@ -1,6 +1,6 @@
 (ns funcool.promesa-test
   (:require
-   [cljs.test :refer [async deftest is testing]]
+   [cljs.test :refer [deftest is async]]
    [sci.configs.funcool.promesa :as promesa-config]
    [sci.core :as sci]))
 

--- a/test/funcool/promesa_test.cljc
+++ b/test/funcool/promesa_test.cljc
@@ -1,9 +1,8 @@
 (ns funcool.promesa-test
   (:require
-   [cljs.test :refer [deftest is async]]
+   [cljs.test :refer [async deftest is testing]]
    [sci.configs.funcool.promesa :as promesa-config]
-   [sci.core :as sci]
-   [promesa.core :as p]))
+   [sci.core :as sci]))
 
 (defn ctx-fn [] (sci/init {:namespaces promesa-config/namespaces}))
 
@@ -29,4 +28,20 @@
                (.catch (fn [_] (is false)))
                (.then (fn [_]
                         (is (= 5 (f)))))
+               (.finally done)))))
+
+(deftest do-exception-safe-test
+  (let [ctx (ctx-fn)
+        p (sci/eval-string* ctx "
+(ns example
+  (:require
+    [promesa.core :as p]))
+
+(p/do (throw (ex-info \"an error\" {:info :test})))")]
+    (async done
+           (-> p
+               (.then (fn [_] (is false)))
+               (.catch (fn [err]
+                         (is (= "an error" (ex-message err)))
+                         (is (= {:info :test} (-> err ex-cause ex-data)))))
                (.finally done)))))


### PR DESCRIPTION
Make promesa.core/do exception safe like it is
upstream. promesa.core/do* remains as the exception unsafe version.

See babashka/nbb#363