### PR TITLE
Add portfolio.replicant config

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -20,6 +20,7 @@
     "shadow-cljs": "^2.25.7"
   },
   "dependencies": {
+    "snabbdom": "3.5.1",
     "w3c-keyname": "^2.2.4"
   }
 }

--- a/playground/src/playground.cljs
+++ b/playground/src/playground.cljs
@@ -20,6 +20,7 @@
    ;; All the configs
    sci.configs.applied-science.js-interop
    sci.configs.cjohansen.replicant
+   sci.configs.cjohansen.portfolio.replicant   
    sci.configs.cljs.pprint
    sci.configs.cljs.test
    ; sci.configs.clojure-1-11
@@ -57,6 +58,7 @@
 (def all-configs ; vars so that we can extract ns info
   [#'sci.configs.applied-science.js-interop/config
    #'sci.configs.cjohansen.replicant/config
+   #'sci.configs.cjohansen.portfolio.replicant/config
    #'sci.configs.cljs.pprint/config
    #'sci.configs.cljs.test/config
    ;#'sci.configs.clojure.test/config

--- a/playground/www/index.html
+++ b/playground/www/index.html
@@ -25,6 +25,8 @@
         [reagent.dom.client :as rdc]
         [reagent.debug]
         [replicant.dom :as replicant]
+        [portfolio.replicant :refer-macros [defscene]]
+        [portfolio.ui :as portfolio]
         [reagent.ratom :as ratom]
         [reitit.frontend :as reitit]
         [datascript.core :as d]
@@ -39,6 +41,9 @@
     [["/api/ping" ::ping]
      ["/api/orders/:id" ::order]]))
 (reitit/match-by-path router "/api/ping")
+
+(defscene hello
+  [:h1 "hello Portfolio"])
         
 (defsc Root [this props]
  (dom/div (dom/h3 "Hello from SCI!")

--- a/src/sci/configs/cjohansen/portfolio/core.cljc
+++ b/src/sci/configs/cjohansen/portfolio/core.cljc
@@ -1,0 +1,55 @@
+(ns sci.configs.cjohansen.portfolio.core
+  (:require [sci.core :as sci]
+            [clojure.pprint]
+            [clojure.string :as str]))
+
+(def pcns (sci/create-ns 'portfolio.core nil))
+
+(defn portfolio-active? [] true)
+
+(defn function-like? [f]
+  (or (symbol? f)
+      (and (list? f) (= 'var (first f)))))
+
+(defn get-code-str [syms]
+  (-> (for [sym syms]
+        (with-out-str (clojure.pprint/pprint sym)))
+      str/join
+      str/trim
+      (str/replace #"let\n\s+" "let ")
+      (str/replace #"if\n\s+" "if ")
+      (str/replace #"when\n\s+" "when ")))
+
+(defn get-options-map [id line syms]
+  (let [docs (when (string? (first syms)) (first syms))
+        pairs (partition-all 2 (drop (if docs 1 0) syms))
+        rest (apply concat (drop-while (comp keyword? first) pairs))
+        fn-like? (function-like? (first rest))]
+    (->> pairs
+         (take-while (comp keyword? first))
+         (map vec)
+         (into (cond
+                 (and (= 1 (count rest)) fn-like?)
+                 {:component-fn (first rest)}
+
+                 (and (not fn-like?)
+                      (or (not (vector? (first rest)))
+                          (= 1 (count rest))))
+                 {:component-fn `(fn [& _#]
+                                   ~@rest)
+                  :code (get-code-str rest)}
+
+                 (< 1 (count rest))
+                 {:component-fn `(fn ~(cond-> (first rest)
+                                        (< (count (first rest)) 2)
+                                        (into ['& 'args]))
+                                   ~@(drop 1 rest))
+                  :code (get-code-str (next rest))}))
+         (into {:id (keyword (str *ns*) (str id))
+                :line line
+                :docs docs}))))
+
+(def portfolio-core-namespace
+  {'portfolio-active? (sci/copy-var portfolio-active? pcns)
+   'get-options-map (sci/copy-var get-options-map pcns)})
+

--- a/src/sci/configs/cjohansen/portfolio/data.cljc
+++ b/src/sci/configs/cjohansen/portfolio/data.cljc
@@ -1,0 +1,8 @@
+(ns sci.configs.cjohansen.portfolio.data
+  (:require [portfolio.data]
+            [sci.core :as sci]))
+
+(def pdns (sci/create-ns 'portfolio.data nil))
+
+(def portfolio-data-namespace 
+  {'register-scene! (sci/copy-var portfolio.data/register-scene! pdns)})

--- a/src/sci/configs/cjohansen/portfolio/replicant.cljs
+++ b/src/sci/configs/cjohansen/portfolio/replicant.cljs
@@ -1,0 +1,30 @@
+(ns sci.configs.cjohansen.portfolio.replicant
+  (:require [sci.configs.cjohansen.portfolio.core :refer [portfolio-core-namespace] :as portfolio]
+            [sci.configs.cjohansen.portfolio.data :refer [portfolio-data-namespace]]
+            [sci.configs.cjohansen.portfolio.ui :refer [portfolio-ui-namespace]]
+            [portfolio.replicant]
+            [sci.core :as sci]))
+
+(def prns (sci/create-ns 'portfolio.replicant nil))
+
+(defn ^:sci/macro defscene
+  "Execute body with the pretty print dispatch function bound to function."
+  [_&form &env id & opts]
+  `(portfolio.data/register-scene!
+      (portfolio.replicant/create-scene
+       ~(portfolio/get-options-map id (:line &env) opts))))
+       
+#_(defn ^:sci/macro configure-scenes [_ _ & opts]
+  `(portfolio.data/register-collection!
+      ~@(portfolio/get-collection-options opts)))
+
+(def portfolio-replicant-namespace
+  {'create-scene (sci/copy-var portfolio.replicant/create-scene prns)
+   'defscene (sci/copy-var defscene prns)})
+
+(def namespaces {'portfolio.core portfolio-core-namespace
+                 'portfolio.data portfolio-data-namespace
+                 'portfolio.replicant portfolio-replicant-namespace
+                 'portfolio.ui portfolio-ui-namespace})
+
+(def config {:namespaces namespaces})

--- a/src/sci/configs/cjohansen/portfolio/ui.cljs
+++ b/src/sci/configs/cjohansen/portfolio/ui.cljs
@@ -1,0 +1,8 @@
+(ns sci.configs.cjohansen.portfolio.ui
+  (:require [portfolio.ui :as rd]
+            [sci.core :as sci]))
+
+(def rdns (sci/create-ns 'portfolio.ui nil))
+
+(def portfolio-ui-namespace
+  {'start! (sci/copy-var rd/start! rdns)})

--- a/test-deps/deps.edn
+++ b/test-deps/deps.edn
@@ -7,6 +7,7 @@
   funcool/promesa {:git/url "https://github.com/funcool/promesa"
                    :git/sha "e503874b154224ce85b223144e80b697df91d18e"}
   no.cjohansen/replicant {:mvn/version "2025.03.27"}
+  no.cjohansen/portfolio {:mvn/version "2025.01.28"}
   reagent/reagent {:mvn/version "1.2.0"}
   metosin/reitit {:mvn/version "0.9.1"}
   re-frame/re-frame {:mvn/version "1.4.0"}


### PR DESCRIPTION
Ask discussed in Slack sci.configs all the things :)

This is the config I've used to get it working with a custom Scittle build.

The playground demo is a bit lame as the portfolio UI wants to take over the whole screen. So I didn't enable the UI. It would also require including the portfolio html assets.